### PR TITLE
Feat/admin auth

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,7 +117,7 @@ void handleAdminLogin(Auth &auth)
   std::string password;
   std::cout << "Masukkan username: ";
   std::cin >> phone;
-  std::cout << "Masukan password: ";
+  std::cout << "Masukkan password: ";
   std::cin >> password;
 
   auth.loginAdmin(phone, password);
@@ -169,61 +169,61 @@ void displayAdminMenu(Auth &auth)
     std::cout << "ANDA BUKAN ADMIN!" << std::endl;
     pause();
     displayMainMenu(auth);
+    return; // Important to prevent further execution
   }
-  else
+
+  Admin *adminUser = dynamic_cast<Admin *>(auth.getCurrentUser());
+  if (!adminUser)
   {
-    Admin a;
-
-    cls();
-    std::cout << "=== MENU ADMIN ===" << std::endl;
-    std::cout << "0. Logout" << std::endl;
-    std::cout << "1. Lihat Jadwal Beserta Datanya" << std::endl;
-    std::cout << "2. Buat Booking Baru" << std::endl;
-    std::cout << "3. Edit Booking" << std::endl;
-    std::cout << "4. Remove Booking" << std::endl;
-    std::cout << "5. View Users" << std::endl;
-    std::cout << "Pilihan: ";
-
-    int choice;
-    std::cin >> choice;
-
-    // Process user selection
-    switch (choice)
-    {
-    case 0:
-      cls();
-      std::cout << "Logout berhasil!" << std::endl;
-      pause();
-      break;
-    case 1:
-      a.viewSchedule();
-      break;
-    case 2:
-      cls();
-      a.makeBooking();
-      pause();
-      break;
-    case 3:
-      a.editBooking();
-      break;
-    case 4:
-      a.removeBooking();
-      break;
-    case 5:
-      a.viewUsers();
-      break;
-    default:
-      std::cout << "Pilihan tidak valid!" << std::endl;
-      pause();
-      break;
-    }
+    std::cout << "Error: Admin cast failed!" << std::endl;
+    pause();
+    displayMainMenu(auth);
+    return;
   }
 
-  // viewSchedule();
-  // makeBooking();
-  // editBooking();
-  // removeBooking();
-  // viewUsers();
+  cls();
+  std::cout << "=== MENU ADMIN ===" << std::endl;
+  std::cout << "0. Logout" << std::endl;
+  std::cout << "1. Lihat Jadwal Beserta Datanya" << std::endl;
+  std::cout << "2. Buat Booking Baru" << std::endl;
+  std::cout << "3. Edit Booking" << std::endl;
+  std::cout << "4. Remove Booking" << std::endl;
+  std::cout << "5. View Users" << std::endl;
+  std::cout << "Pilihan: ";
+
+  int choice;
+  std::cin >> choice;
+
+  // Process user selection
+  switch (choice)
+  {
+  case 0:
+    cls();
+    std::cout << "Logout berhasil!" << std::endl;
+    pause();
+    break;
+  case 1:
+    adminUser->viewSchedule();
+    break;
+  case 2:
+    cls();
+    adminUser->makeBooking();
+    pause();
+    break;
+  case 3:
+    adminUser->editBooking();
+    break;
+  case 4:
+    adminUser->removeBooking();
+    break;
+  case 5:
+    adminUser->viewUsers();
+    break;
+  default:
+    std::cout << "Pilihan tidak valid!" << std::endl;
+    pause();
+    break;
+  }
 
   displayMainMenu(auth); // Kembali ke menu utama setelah selesai
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,7 +175,11 @@ void displayAdminMenu(Auth &auth)
   Admin *adminUser = dynamic_cast<Admin *>(auth.getCurrentUser());
   if (!adminUser)
   {
-    std::cout << "Error: Admin cast failed!" << std::endl;
+    std::cout << "Error: Admin cast failed! Current user is of type '"
+              << typeid(*auth.getCurrentUser()).name()
+              << "' with name '" << auth.getCurrentUser()->getName()
+              << "' and phone '" << auth.getCurrentUser()->getPhoneNumber()
+              << "'. Expected type 'Admin'." << std::endl;
     pause();
     displayMainMenu(auth);
     return;


### PR DESCRIPTION
This pull request makes improvements to the `displayAdminMenu` function in `src/main.cpp` to enhance type safety and prevent potential runtime errors, along with a minor correction to user-facing text. The key changes include adding type checking for the current user, replacing a placeholder `Admin` object with the actual admin user, and fixing a typo in a prompt.

### Improvements to type safety and functionality in `displayAdminMenu`:

* Added a `dynamic_cast` to ensure the current user is of type `Admin`. If the cast fails, an error message is displayed, and the program returns to the main menu to prevent further execution with an invalid user.
* Replaced the placeholder `Admin` object (`a`) with the actual `Admin` user (`adminUser`) for all admin-specific method calls, ensuring the correct user context is used.

### Minor user-facing text correction:

* Fixed a typo in the password prompt by changing "Masukan" to "Masukkan" for proper grammar.